### PR TITLE
Add docker support for Bitcore BTX

### DIFF
--- a/btx/Dockerfile
+++ b/btx/Dockerfile
@@ -1,0 +1,66 @@
+# Build via docker:
+# docker build --build-arg cores=8 -t blocknetdx/bitcore:0.15.2.0 .
+
+FROM ubuntu:xenial
+
+ARG cores=1
+ENV ecores=$cores
+
+RUN apt update \
+  && apt install -y --no-install-recommends \
+     software-properties-common \
+     ca-certificates \
+     wget curl git python vim \
+  && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+RUN add-apt-repository ppa:bitcoin/bitcoin \
+  && apt update \
+  && apt install -y --no-install-recommends \
+     build-essential libtool autotools-dev bsdmainutils \
+     libevent-dev autoconf automake pkg-config libssl-dev \
+     libboost-system-dev libboost-filesystem-dev libboost-chrono-dev \
+     libboost-program-options-dev libboost-test-dev libboost-thread-dev \
+     libdb4.8-dev libdb4.8++-dev libgmp-dev libminiupnpc-dev libzmq5-dev \
+  && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+# Build source
+RUN mkdir -p /opt/bitcore \
+  && mkdir -p /opt/blockchain/config \
+  && mkdir -p /opt/blockchain/data \
+  && ln -s /opt/blockchain/config /root/.bitcore \
+  && cd /opt/bitcore \
+  && git clone --depth 1 --branch 0.15 https://github.com/LIMXTEC/BitCore.git /opt/bitcore/bitcore \
+  && cd /opt/bitcore/bitcore \
+  && chmod +x ./autogen.sh \
+  && ./autogen.sh \
+  && ./configure --without-gui --disable-hardening \
+  && make -j$ecores \
+  && make install \
+  && rm -rf /opt/bitcore/
+
+# Write default bitcore.conf (can be overridden on commandline)
+RUN echo "datadir=/opt/blockchain/data  \n\
+                                        \n\
+dbcache=256                             \n\
+maxmempool=512                          \n\
+                                        \n\
+port=8555    # testnet: 8666            \n\
+rpcport=8556 # testnet: 50332           \n\
+                                        \n\
+listen=1                                \n\
+server=1                                \n\
+maxconnections=16                       \n\
+logtimestamps=1                         \n\
+logips=1                                \n\
+                                        \n\
+rpcallowip=127.0.0.1                    \n\
+rpctimeout=15                           \n\
+rpcclienttimeout=15                     \n" > /opt/blockchain/config/bitcore.conf
+
+WORKDIR /opt/blockchain/
+VOLUME ["/opt/blockchain/config", "/opt/blockchain/data"]
+
+# Port, RPC, Test Port, Test RPC
+EXPOSE 8555 8556 8666 50332
+
+CMD ["bitcored", "-daemon=0"]

--- a/btx/README.md
+++ b/btx/README.md
@@ -1,0 +1,86 @@
+Official Blocknet Bitcore Images
+=================================
+
+These bitcore docker images can be found on the docker hub: https://hub.docker.com/r/blocknetdx/bitcore/
+
+Bitcore
+========
+
+These bitcore images are optimized for use with the Blocknet DX.
+
+**Note**
+
+These images are _not a replacement or endorsement_ of the Bitcore Project (https://github.com/LIMXTEC/BitCore).
+
+
+Simple
+======
+
+Run a simple bitcore node on port 8555:
+```
+docker run -d --name=bitcore -p 8555:8555 blocknetdx/bitcore:latest
+```
+
+
+Persist blockchain w/ volumes
+=============================
+
+Run a bitcore node that persists the blockchain on a host directory. Recommended to avoid time consuming resyncs when updating to later container versions.
+```
+docker run -d --name=bitcore -p 8555:8555 -v=/crypto/bitcore/config:/opt/blockchain/config -v=/crypto/bitcore/data:/opt/blockchain/data blocknetdx/bitcore:0.15.2.0
+```
+
+
+Automatically restart the container
+===================================
+
+See https://docs.docker.com/engine/admin/start-containers-automatically/ 
+
+`--restart=no|on-failure:retrycount|always|unless-stopped`
+
+```
+docker run -d --restart=no --name=bitcore -p 8555:8555 blocknetdx/bitcore:0.15.2.0 bitcored -daemon=0 -rpcuser=btx -rpcpassword=btx123
+docker run -d --restart=on-failure:10 --name=bitcore -p 8555:8555 blocknetdx/bitcore:0.15.2.0 bitcored -daemon=0 -rpcuser=btx -rpcpassword=btx123
+docker run -d --restart=unless-stopped --name=bitcore -p 8555:8555 blocknetdx/bitcore:0.15.2.0 bitcored -daemon=0 -rpcuser=btx -rpcpassword=btx123
+docker run -d --restart=always --name=bitcore -p 8555:8555 blocknetdx/bitcore:0.15.2.0 bitcored -daemon=0 -rpcuser=btx -rpcpassword=btx123
+```
+
+
+Container shell access
+======================
+
+To login to the bitcore container and run RPC commands use the following command:
+```
+docker exec -it bitcore /bin/bash
+```
+
+
+Default bitcore.conf
+=====================
+
+The default configuration is below. A custom configuration file can be passed to the bitcore node container through the `/opt/blockchain/config` volume. Some of these parameters can also be adjusted on the command line.
+```
+datadir=/opt/blockchain/data
+                             
+dbcache=256                  
+maxmempool=512               
+                             
+port=8555    # testnet: 8666
+rpcport=8556 # testnet: 50332
+                             
+listen=1                     
+server=1                     
+maxconnections=16            
+logtimestamps=1              
+logips=1                     
+                             
+rpcallowip=127.0.0.1         
+rpctimeout=15                
+rpcclienttimeout=15
+```
+
+
+License
+=======
+
+This code is licensed under the Apache 2.0 License. Please refer to the [LICENSE](https://github.com/BlocknetDX/dockerimages/blob/master/LICENSE).


### PR DESCRIPTION
The test docker image for this blocknetdx/bitcore:0.15.2.0 Dockerfile can be find in my repo : https://hub.docker.com/r/dalijolijo/blocknetdx_bitcore/