### PR TITLE
Add venv to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .swp*
 blockchain/
 .idea/
+venv/


### PR DESCRIPTION
When building etc in a local environment it may be helpful to use a venv. In which case, ignore it!