### PR TITLE
Custom build raven v4.3.2.1

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -41,7 +41,6 @@ jobs:
       if: ${{ always() }}
       run: yes | docker image prune
     - name: Push an image to DockerHub
-      run: echo Pushing "${{ github.event.inputs.image }}" ${{ github.event.inputs.version }}
       run: ./ci.sh push "${{ github.event.inputs.image }}" ${{ github.event.inputs.version }}
 
 #  staging:

--- a/images/ravencoin/Dockerfile
+++ b/images/ravencoin/Dockerfile
@@ -1,0 +1,78 @@
+# Build via docker:
+# docker build --build-arg cores=8 -t blocknetdx/rvn:latest .
+
+FROM ubuntu:bionic
+
+ARG cores=6
+ENV ecores=$cores
+
+LABEL wallet=ravencoin
+LABEL version=fix-depends
+
+RUN apt update \
+  && apt install -y --no-install-recommends \
+     software-properties-common \
+     ca-certificates \
+     wget curl git python vim \
+  && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+RUN add-apt-repository ppa:bitcoin/bitcoin \
+  && apt update \
+  && apt install -y --no-install-recommends \
+     gcc-8 g++-8 \
+     curl build-essential libtool autotools-dev automake \
+     python3 bsdmainutils cmake libevent-dev autoconf automake \
+     pkg-config libssl-dev libboost-system-dev libboost-filesystem-dev \
+     libboost-chrono-dev libboost-program-options-dev libboost-test-dev \
+     libboost-thread-dev libdb4.8-dev libdb4.8++-dev libgmp-dev \
+     libminiupnpc-dev libzmq3-dev \
+  && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+ENV DISTDIR=/opt/blockchain/dist
+
+# Build source
+RUN mkdir -p /opt/raven \
+  && mkdir -p /opt/blockchain/config \
+  && mkdir -p /opt/blockchain/data \
+  && ln -s /opt/blockchain/config /root/.raven \
+  && cd /opt/raven \
+  && git clone --depth 1 --branch fix-depends https://github.com/walkjivefly/Ravencoin raven \
+  && cd /opt/raven/raven/ \
+  && cd depends \
+  && make -j$ecores NO_QT=1 \
+  && cd .. \
+  && chmod +x ./autogen.sh \
+  && ./autogen.sh \
+  && ./configure CC="gcc-8" CXX="g++-8" --with-gui=no --enable-hardening --prefix=`pwd`/depends/x86_64-pc-linux-gnu \
+  && make -j$ecores \
+  && make install DESTDIR=$DISTDIR \
+  && cp $DISTDIR/opt/raven/raven/depends/x86_64-pc-linux-gnu/bin/* /usr/bin/ \
+  && rm -rf /opt/raven/
+
+# Write default raven.conf (can be overridden on commandline)
+RUN echo "datadir=/opt/blockchain/data  \n\
+                                        \n\
+dbcache=256                             \n\
+maxmempool=512                          \n\
+                                        \n\
+port=8767                               \n\
+rpcport=8766                            \n\
+                                        \n\
+listen=1                                \n\
+txindex=1                               \n\
+server=1                                \n\
+maxconnections=16                       \n\
+logtimestamps=1                         \n\
+logips=1                                \n\
+                                        \n\
+rpcallowip=127.0.0.1                    \n\
+rpcwaittimeout=30                       \n\
+rpcclienttimeout=30                     \n" > /opt/blockchain/config/raven.conf
+
+WORKDIR /opt/blockchain/
+VOLUME ["/opt/blockchain/config", "/opt/blockchain/data"]
+
+# Port, RPC, Test Port, Test RPC
+EXPOSE 8767 8766  18332  19332
+
+CMD ["/usr/bin/ravend", "-daemon=0"]

--- a/images/ravencoin/README.md
+++ b/images/ravencoin/README.md
@@ -1,0 +1,87 @@
+Official Blocknet rvn Images
+=================================
+
+These rvn docker images can be found on the docker hub: https://hub.docker.com/r/blocknetdx/rvn/
+
+rvn
+========
+
+These rvn images are optimized for use with the Blocknet DX.
+
+**Note**
+
+These images are _not a replacement or endorsement_ of the rvn project (https://github.com/walkjivefly/Ravencoin).
+
+
+Simple
+======
+
+Run a simple rvn node on port 8767:
+```
+docker run -d --name=rvn -p 8767:8767 blocknetdx/rvn:fix-depends
+```
+
+
+Persist blockchain w/ volumes
+=============================
+
+Run a rvn node that persists the blockchain on a host directory. Recommended to avoid time consuming resyncs when updating to later container versions.
+```
+docker run -d --name=rvn -p 8767:8767 -v=/crypto/rvn/config:/opt/blockchain/config -v=/crypto/rvn/data:/opt/blockchain/data blocknetdx/rvn:fix-depends
+```
+
+
+Automatically restart the container
+===================================
+
+See https://docs.docker.com/engine/admin/start-containers-automatically/
+
+`--restart=no|on-failure:retrycount|unless-stopped|always`
+
+```
+docker run -d --restart=no --name=rvn -p 8767:8767 blocknetdx/rvn:fix-depends ravend -daemon=0 -rpcuser=RVN -rpcpassword=RVN123
+docker run -d --restart=on-failure:10 --name=rvn -p 8767:8767 blocknetdx/rvn:fix-depends ravend -daemon=0 -rpcuser=RVN -rpcpassword=RVN123
+docker run -d --restart=unless-stopped --name=rvn -p 8767:8767 blocknetdx/rvn:fix-depends ravend -daemon=0 -rpcuser=RVN -rpcpassword=RVN123
+docker run -d --restart=always --name=rvn -p 8767:8767 blocknetdx/rvn:fix-depends ravend -daemon=0 -rpcuser=RVN -rpcpassword=RVN123
+```
+
+
+Container shell access
+======================
+
+To login to the rvn container and run RPC commands use the following command:
+```
+docker exec -it rvn /bin/bash
+```
+
+
+Default raven.conf
+=====================
+
+The default configuration is below. A custom configuration file can be passed to the rvn  node container through the `/opt/blockchain/config` volume. Some of these parameters can also be adjusted on the command line.
+```
+datadir=/opt/blockchain/data
+
+dbcache=256
+maxmempool=512
+
+port=8767
+rpcport=8766
+
+listen=1
+txindex=1
+server=1
+maxconnections=16
+logtimestamps=1
+logips=1
+
+rpcallowip=127.0.0.1
+rpcwaittimeout=30
+rpcclienttimeout=30
+```
+
+
+License
+=======
+
+This code is licensed under the Apache 2.0 License. Please refer to the [LICENSE](https://github.com/BlocknetDX/dockerimages/blob/master/LICENSE).

--- a/images/syscoin/Dockerfile
+++ b/images/syscoin/Dockerfile
@@ -1,0 +1,78 @@
+# Build via docker:
+# docker build --build-arg cores=8 -t blocknetdx/sys:latest .
+
+FROM ubuntu:bionic
+
+ARG cores=6
+ENV ecores=$cores
+
+LABEL wallet=syscoin
+LABEL version=v4.3.0
+
+RUN apt update \
+  && apt install -y --no-install-recommends \
+     software-properties-common \
+     ca-certificates \
+     wget curl git python vim \
+  && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+RUN add-apt-repository ppa:bitcoin/bitcoin \
+  && apt update \
+  && apt install -y --no-install-recommends \
+     gcc-8 g++-8 \
+     curl build-essential libtool autotools-dev automake \
+     python3 bsdmainutils cmake libevent-dev autoconf automake \
+     pkg-config libssl-dev libboost-system-dev libboost-filesystem-dev \
+     libboost-chrono-dev libboost-program-options-dev libboost-test-dev \
+     libboost-thread-dev libdb4.8-dev libdb4.8++-dev libgmp-dev \
+     libminiupnpc-dev libzmq3-dev \
+  && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+ENV DISTDIR=/opt/blockchain/dist
+
+# Build source
+RUN mkdir -p /opt/syscoin \
+  && mkdir -p /opt/blockchain/config \
+  && mkdir -p /opt/blockchain/data \
+  && ln -s /opt/blockchain/config /root/.syscoin \
+  && cd /opt/syscoin \
+  && git clone --depth 1 --branch v4.3.0 https://github.com/syscoin/syscoin syscoin \
+  && cd /opt/syscoin/syscoin/ \
+  && cd depends \
+  && make -j$ecores NO_QT=1 \
+  && cd .. \
+  && chmod +x ./autogen.sh \
+  && ./autogen.sh \
+  && ./configure CC="gcc-8" CXX="g++-8" --with-gui=no --enable-hardening --prefix=`pwd`/depends/x86_64-pc-linux-gnu \
+  && make -j$ecores \
+  && make install DESTDIR=$DISTDIR \
+  && cp $DISTDIR/opt/syscoin/syscoin/depends/x86_64-pc-linux-gnu/bin/* /usr/bin/ \
+  && rm -rf /opt/syscoin/
+
+# Write default syscoin.conf (can be overridden on commandline)
+RUN echo "datadir=/opt/blockchain/data  \n\
+                                        \n\
+dbcache=256                             \n\
+maxmempool=512                          \n\
+                                        \n\
+port=8369                               \n\
+rpcport=8370                            \n\
+                                        \n\
+listen=1                                \n\
+txindex=1                               \n\
+server=1                                \n\
+maxconnections=16                       \n\
+logtimestamps=1                         \n\
+logips=1                                \n\
+                                        \n\
+rpcallowip=127.0.0.1                    \n\
+rpcwaittimeout=30                       \n\
+rpcclienttimeout=30                     \n" > /opt/blockchain/config/syscoin.conf
+
+WORKDIR /opt/blockchain/
+VOLUME ["/opt/blockchain/config", "/opt/blockchain/data"]
+
+# Port, RPC, Test Port, Test RPC
+EXPOSE 8369 8370  18332  19332
+
+CMD ["/usr/bin/syscoind", "-daemon=0"]

--- a/images/syscoin/README.md
+++ b/images/syscoin/README.md
@@ -1,0 +1,87 @@
+Official Blocknet sys Images
+=================================
+
+These sys docker images can be found on the docker hub: https://hub.docker.com/r/blocknetdx/sys/
+
+sys
+========
+
+These sys images are optimized for use with the Blocknet DX.
+
+**Note**
+
+These images are _not a replacement or endorsement_ of the sys project (https://github.com/syscoin/syscoin).
+
+
+Simple
+======
+
+Run a simple sys node on port 8369:
+```
+docker run -d --name=sys -p 8369:8369 blocknetdx/sys:v4.3.0
+```
+
+
+Persist blockchain w/ volumes
+=============================
+
+Run a sys node that persists the blockchain on a host directory. Recommended to avoid time consuming resyncs when updating to later container versions.
+```
+docker run -d --name=sys -p 8369:8369 -v=/crypto/sys/config:/opt/blockchain/config -v=/crypto/sys/data:/opt/blockchain/data blocknetdx/sys:v4.3.0
+```
+
+
+Automatically restart the container
+===================================
+
+See https://docs.docker.com/engine/admin/start-containers-automatically/
+
+`--restart=no|on-failure:retrycount|unless-stopped|always`
+
+```
+docker run -d --restart=no --name=sys -p 8369:8369 blocknetdx/sys:v4.3.0 syscoind -daemon=0 -rpcuser=SYS -rpcpassword=SYS123
+docker run -d --restart=on-failure:10 --name=sys -p 8369:8369 blocknetdx/sys:v4.3.0 syscoind -daemon=0 -rpcuser=SYS -rpcpassword=SYS123
+docker run -d --restart=unless-stopped --name=sys -p 8369:8369 blocknetdx/sys:v4.3.0 syscoind -daemon=0 -rpcuser=SYS -rpcpassword=SYS123
+docker run -d --restart=always --name=sys -p 8369:8369 blocknetdx/sys:v4.3.0 syscoind -daemon=0 -rpcuser=SYS -rpcpassword=SYS123
+```
+
+
+Container shell access
+======================
+
+To login to the sys container and run RPC commands use the following command:
+```
+docker exec -it sys /bin/bash
+```
+
+
+Default syscoin.conf
+=====================
+
+The default configuration is below. A custom configuration file can be passed to the sys  node container through the `/opt/blockchain/config` volume. Some of these parameters can also be adjusted on the command line.
+```
+datadir=/opt/blockchain/data
+
+dbcache=256
+maxmempool=512
+
+port=8369
+rpcport=8370
+
+listen=1
+txindex=1
+server=1
+maxconnections=16
+logtimestamps=1
+logips=1
+
+rpcallowip=127.0.0.1
+rpcwaittimeout=30
+rpcclienttimeout=30
+```
+
+
+License
+=======
+
+This code is licensed under the Apache 2.0 License. Please refer to the [LICENSE](https://github.com/BlocknetDX/dockerimages/blob/master/LICENSE).

--- a/images/syscoin4/Dockerfile
+++ b/images/syscoin4/Dockerfile
@@ -1,118 +1,78 @@
-# Build Geth in a stock Go builder container
-FROM golang:1.16-alpine as go-ethereum
+# Build via docker:
+# docker build --build-arg cores=8 -t blocknetdx/sys:latest .
 
-ARG GETH_REPO=https://github.com/syscoin/go-ethereum.git
-ARG GETH_BRANCH=master
+FROM ubuntu:bionic
 
-RUN set -xe; \
-  apk add --no-cache --virtual .build-deps \
-  make gcc musl-dev linux-headers git; \
-  mkdir -p go-ethereum; \
-  git clone ${GETH_REPO} --branch ${GETH_BRANCH} --depth 1 --single-branch go-ethereum; \
-  cd go-ethereum; \
-  make geth -j$(nproc) all; \
-  apk del .build-deps;
+ARG cores=6
+ENV ecores=$cores
 
-# Build stage for Syscoin Core
-FROM alpine as syscoin-core
+LABEL wallet=syscoin
+LABEL version=v4.3.0
 
-RUN sed -i 's/http\:\/\/dl-cdn.alpinelinux.org/https\:\/\/alpine.global.ssl.fastly.net/g' /etc/apk/repositories
-RUN apk --no-cache add autoconf
-RUN apk --no-cache add automake
-RUN apk --no-cache add build-base
-RUN apk --no-cache add chrpath
-RUN apk --no-cache add file
-RUN apk --no-cache add gnupg
-RUN apk --no-cache add libtool
-RUN apk --no-cache add linux-headers
-RUN apk --no-cache add cmake
-RUN apk --no-cache add libc-dev
-RUN apk --no-cache add make
-RUN apk --no-cache add git
-RUN apk --no-cache add python3
-RUN apk --no-cache add xz
-RUN apk --no-cache add bison
-RUN apk --no-cache add curl
-RUN apk --no-cache add pkgconf
-RUN apk --no-cache add bash
-RUN apk --no-cache add clang
+RUN apt update \
+  && apt install -y --no-install-recommends \
+     software-properties-common \
+     ca-certificates \
+     wget curl git python vim \
+  && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
-RUN set -ex \
-  && for key in \
-    90C8019E36C2E964 \
-  ; do \
-    gpg --batch --keyserver keyserver.ubuntu.com --recv-keys "$key" || \
-    gpg --batch --keyserver pgp.mit.edu --recv-keys "$key" || \
-    gpg --batch --keyserver keyserver.pgp.com --recv-keys "$key" || \
-    gpg --batch --keyserver ha.pool.sks-keyservers.net --recv-keys "$key" || \
-    gpg --batch --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys "$key" ; \
-  done
+RUN add-apt-repository ppa:bitcoin/bitcoin \
+  && apt update \
+  && apt install -y --no-install-recommends \
+     gcc-8 g++-8 \
+     curl build-essential libtool autotools-dev automake \
+     python3 bsdmainutils cmake libevent-dev autoconf automake \
+     pkg-config libssl-dev libboost-system-dev libboost-filesystem-dev \
+     libboost-chrono-dev libboost-program-options-dev libboost-test-dev \
+     libboost-thread-dev libdb4.8-dev libdb4.8++-dev libgmp-dev \
+     libminiupnpc-dev libzmq3-dev \
+  && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
-ENV SYSCOIN_VERSION=4.3.99
-ENV SYSCOIN_PREFIX=/opt/syscoin-${SYSCOIN_VERSION}
+ENV DISTDIR=/opt/blockchain/dist
 
-RUN wget https://github.com/syscoin/syscoin/archive/refs/heads/dev-4.x-nevm.tar.gz
-RUN tar -xzf *.tar.gz
+# Build source
+RUN mkdir -p /opt/syscoin \
+  && mkdir -p /opt/blockchain/config \
+  && mkdir -p /opt/blockchain/data \
+  && ln -s /opt/blockchain/config /root/.syscoin \
+  && cd /opt/syscoin \
+  && git clone --depth 1 --branch v4.3.0 https://github.com/syscoin/syscoin syscoin \
+  && cd /opt/syscoin/syscoin/ \
+  && cd depends \
+  && make -j$ecores NO_QT=1 \
+  && cd .. \
+  && chmod +x ./autogen.sh \
+  && ./autogen.sh \
+  && ./configure CC="gcc-8" CXX="g++-8" --with-gui=no --enable-hardening --prefix=`pwd`/depends/x86_64-pc-linux-gnu \
+  && make -j$ecores \
+  && make install DESTDIR=$DISTDIR \
+  && cp $DISTDIR/opt/syscoin/syscoin/depends/x86_64-pc-linux-gnu/bin/* /usr/bin/ \
+  && rm -rf /opt/syscoin/
 
-WORKDIR /syscoin-dev-4.x-nevm
+# Write default syscoin.conf (can be overridden on commandline)
+RUN echo "datadir=/opt/blockchain/data  \n\
+                                        \n\
+dbcache=256                             \n\
+maxmempool=512                          \n\
+                                        \n\
+port=8369                               \n\
+rpcport=8370                            \n\
+                                        \n\
+listen=1                                \n\
+txindex=1                               \n\
+server=1                                \n\
+maxconnections=16                       \n\
+logtimestamps=1                         \n\
+logips=1                                \n\
+                                        \n\
+rpcallowip=127.0.0.1                    \n\
+rpcwaittimeout=30                       \n\
+rpcclienttimeout=30                     \n" > /opt/blockchain/config/syscoin.conf
 
-RUN sed -i '/AC_PREREQ/a\AR_FLAGS=cr' src/univalue/configure.ac
-RUN sed -i '/AX_PROG_CC_FOR_BUILD/a\AR_FLAGS=cr' src/secp256k1/configure.ac
-RUN sed -i s:sys/fcntl.h:fcntl.h: src/compat.h
-RUN make -C depends -j $(nproc)
-RUN ./autogen.sh
-RUN CONFIG_SITE=$PWD/depends/x86_64-pc-linux-musl/share/config.site  ./configure \  
-    --prefix=${SYSCOIN_PREFIX} \
-    --mandir=/usr/share/man \
-    --disable-tests \
-    --disable-bench \
-    --disable-ccache \
-    --disable-maintainer-mode \
-    --disable-dependency-tracking \
-    --enable-reduce-exports \
-    --with-gui=no \
-    --with-utils \
-    --with-libs \
-    --with-daemon \
-    CC=clang CXX=clang++ \
-    CFLAGS="-O2 -g0 --static -static -fPIC" \
-    CXXFLAGS="-O2 -g0 --static -static -fPIC" \
-    LDFLAGS="-s -static-libgcc -static-libstdc++ -Wl,-O2"
+WORKDIR /opt/blockchain/
+VOLUME ["/opt/blockchain/config", "/opt/blockchain/data"]
 
-RUN make install -j $(nproc)
-RUN strip ${SYSCOIN_PREFIX}/bin/syscoin-cli
-RUN strip ${SYSCOIN_PREFIX}/bin/syscoin-tx
-RUN strip ${SYSCOIN_PREFIX}/bin/syscoind
+# Port, RPC, Test Port, Test RPC
+EXPOSE 8369 8370  18332  19332
 
-
-# Build stage for compiled artifacts
-FROM alpine
-
-LABEL maintainer.0="Jagdeep Sidhu (@realSidhuJag)"
-
-RUN adduser -S syscoin
-RUN sed -i 's/http\:\/\/dl-cdn.alpinelinux.org/https\:\/\/alpine.global.ssl.fastly.net/g' /etc/apk/repositories
-RUN apk --no-cache add wget su-exec
-
-ENV SYSCOIN_DATA=/home/syscoin/.syscoin
-ENV SYSCOIN_VERSION=4.3.99
-ENV SYSCOIN_PREFIX=/opt/syscoin-${SYSCOIN_VERSION}
-ENV PATH=${SYSCOIN_PREFIX}/bin:$PATH
-
-# Copy NEVM binary to the container
-COPY --from=go-ethereum /go/go-ethereum/build/bin/geth ${SYSCOIN_DATA}/sysgeth
-COPY --from=go-ethereum /go/go-ethereum/build/bin/faucet ${SYSCOIN_DATA}/faucet
-RUN wget https://raw.githubusercontent.com/syscoin/descriptors/master/gethdescriptor.json -O ${SYSCOIN_DATA}/gethdescriptor.json
-
-COPY --from=syscoin-core /opt /opt
-COPY docker-entrypoint.sh /entrypoint.sh
-
-VOLUME ["/home/syscoin/.syscoin"]
-
-EXPOSE 8369 8370 18369 18370 18443 18444 38332 38333
-
-ENTRYPOINT ["/entrypoint.sh"]
-
-RUN syscoind -version | grep "Syscoin Core version v${SYSCOIN_VERSION}"
-
-CMD ["syscoind"]
+CMD ["/usr/bin/syscoind", "-daemon=0"]


### PR DESCRIPTION
This is a crude but effective kludge to create a custom Raven Docker build image
 
It uses https://github.com/walkjivefly/Ravencoin brnach fix-depends because https://github.com/RavenProject/Ravencoin/pull/1146 was rejected by the Raven team which means it's not possible to build Raven 4.3.2.1 from their repo directly.

After this PR is merged the correct way to generate a RVN v4.3.2.1 image is to run the custom build workflow.
It should be possible to build the next version directly from the Raven repo because they have included the necessary changes in master.  

Following on from https://github.com/blocknetdx/dockerimages/pull/43 it used GCC 8 without any problems. 