### PR TITLE
Use actual datadir name

### DIFF
--- a/autobuild/generate_build_files.py
+++ b/autobuild/generate_build_files.py
@@ -79,8 +79,7 @@ for blockchain in manifest_config:
         walletGitTag = blockchain['ver_id'].split('--')
         walletGitURL = blockchain['repo_url']
         walletConfName = blockchain['conf_name']
-        walletLinuxDir = blockchain['conf_name'].split('.conf')
-        walletLinuxDir = walletLinuxDir[0]
+        walletLinuxDir = blockchain['dir_name_linux']
         walletTicker = blockchain['ticker']
         walletVerList = blockchain['versions']
         testnetPort = '18332'


### PR DESCRIPTION
This fixes the problem of some Docker images needing to specify the datadir on xxx-cli commands. The problem happens because the image is built with the wrong datadir name (derived from the config file name) instead of using the actual datadir name as specified in the manifest. 