### PR TITLE
Dogecash 5.4.4

### DIFF
--- a/.github/workflows/build-custom-images.yaml
+++ b/.github/workflows/build-custom-images.yaml
@@ -4,12 +4,20 @@ on:
   workflow_dispatch:
     inputs:
       image:
-        description: Name of wallet
+        description: The full name of the wallet. Example - bitcoin, dash, blocknet.
         required: true
       version:
-        description: Tag of an image
+        description: Version (this will also be used in the tag of the image).
         required: true
         default: latest
+      path:
+        description: Full raw path of a branch where the config can be found.
+        required: false
+        default: https://raw.githubusercontent.com/blocknetdx/blockchain-configuration-files/master
+      repo:
+        description: DockerHub repo name.
+        required: true
+        default: blocknetdx
 
 jobs:
 
@@ -24,12 +32,12 @@ jobs:
     - name: INFO BUILD
       run: echo ${{ github.event.inputs.image }} ${{ github.event.inputs.version }}
     - name: build an image
-      run: ./ci.sh build "${{ github.event.inputs.image }}" ${{ github.event.inputs.version }}
+      run: ./ci.sh build "${{ github.event.inputs.image }}" "${{ github.event.inputs.version }}" "*" "${{ github.events.inputs.repo }}"
     - name: Remove dangling images
       if: ${{ always() }}
       run: yes | docker image prune
     - name: Push an image to DockerHub
-      run: ./ci.sh push "${{ github.event.inputs.image }}" ${{ github.event.inputs.version }}
+      run: ./ci.sh push "${{ github.event.inputs.image }}" "${{ github.event.inputs.version }}" "*" "${{ github.events.inputs.repo }}"
 
 #  staging:
 #    if: ${{ github.event.pull_request }}
@@ -40,3 +48,4 @@ jobs:
 #
 #    - name: Test new image
 #      run: echo "Some test"
+

--- a/.github/workflows/build-from-config.yaml
+++ b/.github/workflows/build-from-config.yaml
@@ -4,18 +4,22 @@ on:
   workflow_dispatch:
     inputs:
       image:
-        description: The full name of a wallet. Example - bitcoin, dash, blocknet.
+        description: The full name of the wallet. Example - bitcoin, dash, blocknet.
         required: true
       version:
-        description: Tag or version of an image, please check manifest-latest.json. By default it takes the newest version.
+        description: Wallet version. Please check manifest-latest.json. By default it takes the newest version.
         required: false
         default: latest
       manifest:
-        description: manifest config file
+        description: Raw manifest config file contents.
         required: false
       wallet_conf:
-        description: wallet config file
+        description: Raw wallet config file contents.
         default: false
+      repo:
+        description: DockerHub repo name.
+        required: true
+        default: blocknetdx
 
 jobs:
 
@@ -30,20 +34,21 @@ jobs:
     - name: INFO BUILD
       run: echo ${{ github.event.inputs.image }} ${{ github.event.inputs.version }}
     - name: generate a Dockerfile
-      run: ./generate.sh "${{ github.event.inputs.image }}" ${{ github.event.inputs.version }} '${{ github.event.inputs.manifest}}' '${{ github.event.inputs.wallet_conf}}'
+      run: ./generate.sh "${{ github.event.inputs.image }}" "${{ github.event.inputs.version }}" "${{ github.event.inputs.manifest }}" "${{ github.event.inputs.wallet_conf }}"
     - name: build an image
-      run: ./ci.sh build "${{ github.event.inputs.image }}" ${{ github.event.inputs.version }}
+      run: ./ci.sh build "${{ github.event.inputs.image }}" "${{ github.event.inputs.version }}" "*" "${{ github.event.inputs.repo }}"
     - name: Run a container
-      run: ./ci.sh run "${{ github.event.inputs.image }}" ${{ github.event.inputs.version }}
-    - name: Test build
-      run: ./ci.sh test "${{ github.event.inputs.image }}" ${{ github.event.inputs.version }}
+      run: ./ci.sh run "${{ github.event.inputs.image }}" "${{ github.event.inputs.version }}" "*" "${{ github.event.inputs.repo }}"
+    # TODO: next step commented out until generate_build_files.py is updated to read the *local* manifest to find the daemon stem
+    #- name: Test build
+    #  run: ./ci.sh test "${{ github.event.inputs.image }}" "${{ github.event.inputs.version }}"
     - name: Remove a container
-      run: ./ci.sh clean "${{ github.event.inputs.image }}" ${{ github.event.inputs.version }}
+      run: ./ci.sh clean "${{ github.event.inputs.image }}" "${{ github.event.inputs.version }}"
     - name: Remove dangling images
       if: ${{ always() }}
       run: yes | docker image prune
     - name: Push an image to DockerHub
-      run: ./ci.sh push "${{ github.event.inputs.image }}" ${{ github.event.inputs.version }}
+      run: ./ci.sh push "${{ github.event.inputs.image }}" "${{ github.event.inputs.version }}" "*" "${{ github.event.inputs.repo }}"
 
 #  staging:
 #    if: ${{ github.event.pull_request }}
@@ -54,3 +59,4 @@ jobs:
 #
 #    - name: Test new image
 #      run: echo "Some test"
+ 

--- a/.github/workflows/build-servicenode.yaml
+++ b/.github/workflows/build-servicenode.yaml
@@ -8,11 +8,15 @@ on:
         required: true
         default: servicenode
       version:
-        description: Tag or version of an image
+        description: Version tag to apply to image (example v4.3.3)
         required: true
       branch:
-        description: branch
+        description: Branch name (example 4.3.3)
         required: true
+      repo:
+        description: DockerHub repo name.
+        required: true
+        default: blocknetdx
 
 jobs:
 
@@ -27,18 +31,18 @@ jobs:
     - name: INFO BUILD
       run: echo ${{ github.event.inputs.image }} ${{ github.event.inputs.version }} ${{ github.event.inputs.branch }}
     - name: build an image
-      run: ./ci.sh build "${{ github.event.inputs.image }}" ${{ github.event.inputs.version }} ${{ github.event.inputs.branch }}
+      run: ./ci.sh build "${{ github.event.inputs.image }}" "${{ github.event.inputs.version }}" "${{ github.event.inputs.branch }}" "${{ github.event.inputs.repo }}"
     - name: Run a container
-      run: ./ci.sh run "${{ github.event.inputs.image }}" ${{ github.event.inputs.version }}
+      run: ./ci.sh run "${{ github.event.inputs.image }}" "${{ github.event.inputs.version }}" "*" "${{ github.event.inputs.repo }}"
     - name: Test build
-      run: ./ci.sh test "${{ github.event.inputs.image }}" ${{ github.event.inputs.version }}
+      run: ./ci.sh test "${{ github.event.inputs.image }}" "${{ github.event.inputs.version }}"
     - name: Remove a container
-      run: ./ci.sh clean "${{ github.event.inputs.image }}" ${{ github.event.inputs.version }}
+      run: ./ci.sh clean "${{ github.event.inputs.image }}" "${{ github.event.inputs.version }}"
     - name: Remove dangling images
       if: ${{ always() }}
       run: yes | docker image prune
     - name: Push an image to DockerHub
-      run: ./ci.sh push "${{ github.event.inputs.image }}" ${{ github.event.inputs.version }}
+      run: ./ci.sh push "${{ github.event.inputs.image }}" "${{ github.event.inputs.version }}" "*" "${{ github.event.inputs.repo }}"
 
 #  staging:
 #    if: ${{ github.event.pull_request }}
@@ -49,3 +53,4 @@ jobs:
 #
 #    - name: Test new image
 #      run: echo "Some test"
+

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -3,17 +3,21 @@ name: BUILD IMAGE FROM TEMPLATE
 on:
   workflow_dispatch:
     inputs:
-      path:
-        description: Full path of a branch where the config can be found.
-        required: false
-        default: https://raw.githubusercontent.com/blocknetdx/blockchain-configuration-files/master
       image:
-        description: The full name of a wallet. Example - bitcoin, dash, blocknet.
+        description: The full name of the wallet. Example - bitcoin, dash, blocknet.
         required: true
       version:
         description: Tag or version of an image, please check manifest-latest.json. By default it takes the newest version.
         required: false
         default: latest
+      path:
+        description: Full raw path of a branch where the config can be found.
+        required: false
+        default: https://raw.githubusercontent.com/blocknetdx/blockchain-configuration-files/master
+      repo:
+        description: DockerHub repo name.
+        required: true
+        default: blocknetdx
 
 jobs:
 
@@ -30,9 +34,9 @@ jobs:
     - name: generate a Dockerfile
       run: ./ci.sh generate "${{ github.event.inputs.image }}" "${{ github.event.inputs.version }}" "${{ github.event.inputs.path }}"
     - name: build an image
-      run: ./ci.sh build "${{ github.event.inputs.image }}" "${{ github.event.inputs.version }}"
+      run: ./ci.sh build "${{ github.event.inputs.image }}" "${{ github.event.inputs.version }}" "*" "${{ github.event.inputs.repo }}"
     - name: Run a container
-      run: ./ci.sh run "${{ github.event.inputs.image }}" "${{ github.event.inputs.version }}"
+      run: ./ci.sh run "${{ github.event.inputs.image }}" "${{ github.event.inputs.version }}" "*" "${{ github.event.inputs.repo }}"
     - name: Test build
       run: ./ci.sh test "${{ github.event.inputs.image }}" "${{ github.event.inputs.version }}" "${{ github.event.inputs.path }}"
     - name: Remove a container
@@ -41,7 +45,7 @@ jobs:
       if: ${{ always() }}
       run: yes | docker image prune
     - name: Push an image to DockerHub
-      run: ./ci.sh push "${{ github.event.inputs.image }}" "${{ github.event.inputs.version }}"
+      run: ./ci.sh push "${{ github.event.inputs.image }}" "${{ github.event.inputs.version }}" "*" "${{ github.event.inputs.repo }}"
 
 #  staging:
 #    if: ${{ github.event.pull_request }}
@@ -52,3 +56,4 @@ jobs:
 #
 #    - name: Test new image
 #      run: echo "Some test"
+ 

--- a/.github/workflows/publish-as-latest.yaml
+++ b/.github/workflows/publish-as-latest.yaml
@@ -1,4 +1,4 @@
-name: RELEASE IMAGE
+name: RELEASE IMAGE AS LATEST
 
 on:
   workflow_dispatch:
@@ -7,7 +7,7 @@ on:
         description: The full name of the wallet. Example - bitcoin, dash, blocknet.
         required: true
       version:
-        description: Version (this will also be used in the tag of the image).
+        description: Version to re-tag as "latest".
         required: true
       repo:
         description: DockerHub repo name.
@@ -23,7 +23,7 @@ jobs:
     - uses: actions/checkout@v2
     - name: Login to DockerHub
       run: echo ${{ secrets.docker_password }} | docker login --username ${{ secrets.docker_username }} --password-stdin
-    - name: INFO RELEASE
+    - name: INFO RELEASE AS LATEST
       run: echo ${{ github.event.inputs.name }} ${{ github.event.inputs.version }}
     - name: Push an image to DockerHub
-      run: ./ci.sh release "${{ github.event.inputs.name }}" "${{ github.event.inputs.version }}" "*" "${{ github.event.inputs.repo }}"
+      run: ./ci.sh release-as-latest "${{ github.event.inputs.name }}" "${{ github.event.inputs.version }}" "*" "${{ github.event.inputs.repo }}"

--- a/autobuild/generate_build_files.py
+++ b/autobuild/generate_build_files.py
@@ -79,8 +79,7 @@ for blockchain in manifest_config:
         walletGitTag = blockchain['ver_id'].split('--')
         walletGitURL = blockchain['repo_url']
         walletConfName = blockchain['conf_name']
-        walletLinuxDir = blockchain['conf_name'].split('.conf')
-        walletLinuxDir = walletLinuxDir[0]
+        walletLinuxDir = blockchain['dir_name_linux']
         walletTicker = blockchain['ticker']
         walletVerList = blockchain['versions']
         testnetPort = '18332'

--- a/images/dogecash/Dockerfile
+++ b/images/dogecash/Dockerfile
@@ -1,0 +1,80 @@
+# Build via docker:
+# docker build --build-arg cores=8 -t blocknetdx/dogec:latest .
+
+FROM ubuntu:bionic
+
+ARG cores=6
+ENV ecores=$cores
+
+LABEL wallet=dogecash
+LABEL version=5.4.4
+
+RUN apt update \
+  && apt install -y --no-install-recommends \
+     software-properties-common \
+     ca-certificates \
+     wget curl git python vim \
+  && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+RUN add-apt-repository ppa:bitcoin/bitcoin \
+  && apt update \
+  && apt install -y --no-install-recommends \
+     gcc-8 g++-8 \
+     curl build-essential libtool autotools-dev automake \
+     python3 bsdmainutils cmake libevent-dev autoconf automake \
+     pkg-config libssl-dev libboost-system-dev libboost-filesystem-dev \
+     libboost-chrono-dev libboost-program-options-dev libboost-test-dev \
+     libboost-thread-dev libdb4.8-dev libdb4.8++-dev libgmp-dev \
+     libminiupnpc-dev libzmq3-dev libattr1-dev zlib1g-dev \
+  && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+ENV DISTDIR=/opt/blockchain/dist
+
+# Build source
+RUN mkdir -p /opt/dogecash \
+  && mkdir -p /opt/blockchain/config \
+  && mkdir -p /opt/blockchain/data \
+  && ln -s /opt/blockchain/config /root/.dogecash \
+  && cd /opt/dogecash \
+  && git clone https://github.com/dogecash/dogecash dogecash \
+  && cd /opt/dogecash/dogecash/ \
+  && git checkout 9c83bb764d05b18225a43fc977fededa074cf7b1 \
+  && cd depends \
+  && make -j$ecores NO_QT=1 \
+  && cd .. \
+  && chmod +x ./autogen.sh \
+  && ./autogen.sh \
+  && ./configure CC="gcc-8" CXX="g++-8" CXXFLAGS="-Wno-error=return-type" --disable-tests --disable-bench --without-miniupnpc --with-gui=no --enable-hardening --prefix=`pwd`/depends/x86_64-pc-linux-gnu \
+  && make -j$ecores \
+  && make install DESTDIR=$DISTDIR \
+  && cp -r $DISTDIR/opt/dogecash/dogecash/depends/x86_64-pc-linux-gnu/bin/* /usr/bin/ \
+  && cp -r $DISTDIR/opt/dogecash/dogecash/depends/x86_64-pc-linux-gnu/share/* /usr/share/ \
+  && rm -rf /opt/dogecash/
+
+# Write default dogecash.conf (can be overridden on commandline)
+RUN echo "datadir=/opt/blockchain/data  \n\
+                                        \n\
+dbcache=256                             \n\
+maxmempool=512                          \n\
+                                        \n\
+port=6740                               \n\
+rpcport=6783                            \n\
+                                        \n\
+listen=1                                \n\
+txindex=1                               \n\
+server=1                                \n\
+maxconnections=16                       \n\
+logtimestamps=1                         \n\
+logips=1                                \n\
+                                        \n\
+rpcallowip=127.0.0.1                    \n\
+rpctimeout=30                           \n\
+rpcclienttimeout=30                     \n" > /opt/blockchain/config/dogecash.conf
+
+WORKDIR /opt/blockchain/
+VOLUME ["/opt/blockchain/config", "/opt/blockchain/data"]
+
+# Port, RPC, Test Port, Test RPC
+EXPOSE 6740 6783  18332  19332
+
+CMD ["/usr/bin/dogecashd", "-daemon=0"]

--- a/images/dogecash/README.md
+++ b/images/dogecash/README.md
@@ -1,0 +1,87 @@
+Official Blocknet dogec Images
+=================================
+
+These dogec docker images can be found on the docker hub: https://hub.docker.com/r/blocknetdx/dogec/
+
+dogec
+========
+
+These dogec images are optimized for use with the Blocknet DX.
+
+**Note**
+
+These images are _not a replacement or endorsement_ of the dogec project (https://github.com/dogecash/dogecash).
+
+
+Simple
+======
+
+Run a simple dogec node on port 6740:
+```
+docker run -d --name=dogec -p 6740:6740 blocknetdx/dogec:5.4.4
+```
+
+
+Persist blockchain w/ volumes
+=============================
+
+Run a dogec node that persists the blockchain on a host directory. Recommended to avoid time consuming resyncs when updating to later container versions.
+```
+docker run -d --name=dogec -p 6740:6740 -v=/crypto/dogec/config:/opt/blockchain/config -v=/crypto/dogec/data:/opt/blockchain/data blocknetdx/dogec:5.4.4
+```
+
+
+Automatically restart the container
+===================================
+
+See https://docs.docker.com/engine/admin/start-containers-automatically/
+
+`--restart=no|on-failure:retrycount|unless-stopped|always`
+
+```
+docker run -d --restart=no --name=dogec -p 6740:6740 blocknetdx/dogec:5.4.4 dogecashd -daemon=0 -rpcuser=DOGEC -rpcpassword=DOGEC123
+docker run -d --restart=on-failure:10 --name=dogec -p 6740:6740 blocknetdx/dogec:5.4.4 dogecashd -daemon=0 -rpcuser=DOGEC -rpcpassword=DOGEC123
+docker run -d --restart=unless-stopped --name=dogec -p 6740:6740 blocknetdx/dogec:5.4.4 dogecashd -daemon=0 -rpcuser=DOGEC -rpcpassword=DOGEC123
+docker run -d --restart=always --name=dogec -p 6740:6740 blocknetdx/dogec:5.4.4 dogecashd -daemon=0 -rpcuser=DOGEC -rpcpassword=DOGEC123
+```
+
+
+Container shell access
+======================
+
+To login to the dogec container and run RPC commands use the following command:
+```
+docker exec -it dogec /bin/bash
+```
+
+
+Default dogecash.conf
+=====================
+
+The default configuration is below. A custom configuration file can be passed to the dogec  node container through the `/opt/blockchain/config` volume. Some of these parameters can also be adjusted on the command line.
+```
+datadir=/opt/blockchain/data
+
+dbcache=256
+maxmempool=512
+
+port=6740
+rpcport=6783
+
+listen=1
+txindex=1
+server=1
+maxconnections=16
+logtimestamps=1
+logips=1
+
+rpcallowip=127.0.0.1
+rpcwaittimeout=30
+rpcclienttimeout=30
+```
+
+
+License
+=======
+
+This code is licensed under the Apache 2.0 License. Please refer to the [LICENSE](https://github.com/BlocknetDX/dockerimages/blob/master/LICENSE).


### PR DESCRIPTION
Custom dockerfile for dogecash 5.4.4 because standard build from source doesn't work.

Bonus changes to the actions/workflows
     * Parameterise the Docker Hub repo name (most useful when running locally)
     * Add repo prompt to actions/workflows
     * Add re-tag as latest action/workflow
     * Improve some action/workflow prompts
   
The bonus changes are a precursor to migrating the DockerHub repo name to blockdx in the hopes this will resolve the permission problem when trying to push some images (eg: SCC, DOGEC and others).  Everything is tested in Github except re-tag as latest which won't appear in the Actions until the change is merged (it worked locally).