### PR TITLE
Issue 49

### DIFF
--- a/.github/workflows/build-custom-images.yaml
+++ b/.github/workflows/build-custom-images.yaml
@@ -26,7 +26,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Login to DockerHub
-      run: echo ${{ secrets.docker_password }} | docker login --username ${{ secrets.docker_username }} --password-stdin
+      run: echo ${{ secrets.org_blocknetdximg_password }} | docker login --username ${{ secrets.org_blocknetdximg_username }} --password-stdin
 
     # Build images
     - name: INFO BUILD

--- a/.github/workflows/build-custom-images.yaml
+++ b/.github/workflows/build-custom-images.yaml
@@ -22,7 +22,7 @@ on:
 jobs:
 
   build:
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
     - name: Login to DockerHub
@@ -42,7 +42,7 @@ jobs:
 #  staging:
 #    if: ${{ github.event.pull_request }}
 #    needs: build
-#    runs-on: self-hosted
+#    runs-on: ubuntu-latest
 #    steps:
 #    - uses: actions/checkout@v2
 #

--- a/.github/workflows/build-from-config.yaml
+++ b/.github/workflows/build-from-config.yaml
@@ -28,7 +28,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Login to DockerHub
-      run: echo ${{ secrets.docker_password }} | docker login --username ${{ secrets.docker_username }} --password-stdin
+      run: echo ${{ secrets.org_blocknetdximg_password }} | docker login --username ${{ secrets.org_blocknetdximg_username }} --password-stdin
 
     # Build images
     - name: INFO BUILD

--- a/.github/workflows/build-from-config.yaml
+++ b/.github/workflows/build-from-config.yaml
@@ -24,7 +24,7 @@ on:
 jobs:
 
   build:
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
     - name: Login to DockerHub
@@ -53,7 +53,7 @@ jobs:
 #  staging:
 #    if: ${{ github.event.pull_request }}
 #    needs: build
-#    runs-on: self-hosted
+#    runs-on: ubuntu-latest
 #    steps:
 #    - uses: actions/checkout@v2
 #

--- a/.github/workflows/build-servicenode.yaml
+++ b/.github/workflows/build-servicenode.yaml
@@ -21,7 +21,7 @@ on:
 jobs:
 
   build:
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
     - name: Login to DockerHub
@@ -47,7 +47,7 @@ jobs:
 #  staging:
 #    if: ${{ github.event.pull_request }}
 #    needs: build
-#    runs-on: self-hosted
+#    runs-on: ubuntu-latest
 #    steps:
 #    - uses: actions/checkout@v2
 #

--- a/.github/workflows/build-servicenode.yaml
+++ b/.github/workflows/build-servicenode.yaml
@@ -25,7 +25,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Login to DockerHub
-      run: echo ${{ secrets.docker_password }} | docker login --username ${{ secrets.docker_username }} --password-stdin
+      run: echo ${{ secrets.org_blocknetdximg_password }} | docker login --username ${{ secrets.org_blocknetdximg_username }} --password-stdin
 
     # Build images
     - name: INFO BUILD

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -26,7 +26,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Login to DockerHub
-      run: echo ${{ secrets.docker_password }} | docker login --username ${{ secrets.docker_username }} --password-stdin
+      run: echo ${{ secrets.org_blocknetdximg_password }} | docker login --username ${{ secrets.org_blocknetdximg_username }} --password-stdin
 
     # Build images
     - name: INFO BUILD

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -22,7 +22,7 @@ on:
 jobs:
 
   build:
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
     - name: Login to DockerHub
@@ -50,7 +50,7 @@ jobs:
 #  staging:
 #    if: ${{ github.event.pull_request }}
 #    needs: build
-#    runs-on: self-hosted
+#    runs-on: ubuntu-latest
 #    steps:
 #    - uses: actions/checkout@v2
 #

--- a/.github/workflows/publish-as-latest.yaml
+++ b/.github/workflows/publish-as-latest.yaml
@@ -17,7 +17,7 @@ on:
 jobs:
 
   release:
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/publish-as-latest.yaml
+++ b/.github/workflows/publish-as-latest.yaml
@@ -22,7 +22,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Login to DockerHub
-      run: echo ${{ secrets.docker_password }} | docker login --username ${{ secrets.docker_username }} --password-stdin
+      run: echo ${{ secrets.org_blocknetdximg_password }} | docker login --username ${{ secrets.org_blocknetdximg_username }} --password-stdin
     - name: INFO RELEASE AS LATEST
       run: echo ${{ github.event.inputs.name }} ${{ github.event.inputs.version }}
     - name: Push an image to DockerHub

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -17,7 +17,7 @@ on:
 jobs:
 
   release:
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -22,7 +22,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Login to DockerHub
-      run: echo ${{ secrets.docker_password }} | docker login --username ${{ secrets.docker_username }} --password-stdin
+      run: echo ${{ secrets.org_blocknetdximg_password }} | docker login --username ${{ secrets.org_blocknetdximg_username }} --password-stdin
     - name: INFO RELEASE
       run: echo ${{ github.event.inputs.name }} ${{ github.event.inputs.version }}
     - name: Push an image to DockerHub

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -26,4 +26,4 @@ jobs:
     - name: INFO RELEASE
       run: echo ${{ github.event.inputs.name }} ${{ github.event.inputs.version }}
     - name: Push an image to DockerHub
-      run: ./ci.sh release "${{ github.event.inputs.name }}" "${{ github.event.inputs.version }}" "*" "${{ github.event.inputs.repo }}"
+      run: ./release.sh "${{ github.event.inputs.name }}" "${{ github.event.inputs.version }}"


### PR DESCRIPTION
Fixes dockerhub login to be able to push previously failing images.
Switches to Github-hosted runners.
Switches to "external" release script to avoid adding more complex logic in ci.sh 
