### PR TITLE
Custom build for DASH 18.0.1

### DIFF
--- a/images/dash/Dockerfile
+++ b/images/dash/Dockerfile
@@ -1,0 +1,77 @@
+# Build via docker:
+# docker build --build-arg cores=8 -t blocknetdx/dash:latest .
+
+FROM ubuntu:bionic
+
+ARG cores=4
+ENV ecores=$cores
+
+LABEL wallet=dash
+LABEL version=v0.18.0.1
+
+RUN apt update \
+  && apt install -y --no-install-recommends \
+     software-properties-common \
+     ca-certificates \
+     wget curl git python vim \
+  && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+RUN add-apt-repository ppa:bitcoin/bitcoin \
+  && apt update \
+  && apt install -y --no-install-recommends \
+     gcc-8 g++-8 \
+     curl build-essential libtool autotools-dev automake \
+     python3 bsdmainutils cmake libevent-dev autoconf automake \
+     pkg-config libssl-dev libboost-system-dev libboost-filesystem-dev \
+     libboost-chrono-dev libboost-program-options-dev libboost-test-dev \
+     libboost-thread-dev libdb4.8-dev libdb4.8++-dev libgmp-dev \
+     libminiupnpc-dev libzmq3-dev libattr1-dev zlib1g-dev \
+  && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+ENV DISTDIR=/opt/blockchain/dist
+
+# Build source
+RUN mkdir -p /opt/dashcore \
+  && mkdir -p /opt/blockchain/config \
+  && mkdir -p /opt/blockchain/data \
+  && ln -s /opt/blockchain/config /root/.dashcore \
+  && cd /opt/dashcore \
+  && wget https://github.com/dashpay/dash/releases/download/v18.0.1/dashcore-18.0.1.tar.gz \
+  && tar -xf dashcore-18.0.1.tar.gz \
+  && cd dashcore-18.0.1 \
+  && NO_QT=1 make -j$ecores -C depends \
+  && chmod +x ./autogen.sh \
+  && ./autogen.sh \
+  && ./configure CC="gcc-8" CXX="g++-8" CXXFLAGS="-Wno-error=return-type" --with-gui=no --enable-hardening --prefix=`pwd`/depends/x86_64-pc-linux-gnu \
+  && make -j$ecores \
+  && make install DESTDIR=$DISTDIR \
+  && cp $DISTDIR/opt/dashcore/dashcore-18.0.1/depends/x86_64-pc-linux-gnu/bin/* /usr/bin/ \
+  && rm -rf /opt/dashcore/
+
+# Write default dash.conf (can be overridden on commandline)
+RUN echo "datadir=/opt/blockchain/data  \n\
+                                        \n\
+dbcache=256                             \n\
+maxmempool=512                          \n\
+                                        \n\
+port=9999                               \n\
+rpcport=9998                            \n\
+                                        \n\
+listen=1                                \n\
+txindex=1                               \n\
+server=1                                \n\
+maxconnections=16                       \n\
+logtimestamps=1                         \n\
+logips=1                                \n\
+                                        \n\
+rpcallowip=127.0.0.1                    \n\
+rpctimeout=30                           \n\
+rpcclienttimeout=30                     \n" > /opt/blockchain/config/dash.conf
+
+WORKDIR /opt/blockchain/
+VOLUME ["/opt/blockchain/config", "/opt/blockchain/data"]
+
+# Port, RPC, Test Port, Test RPC
+EXPOSE 9999 9998  18332  19332
+
+CMD ["/usr/bin/dashd", "-daemon=0"]

--- a/images/dash/README.md
+++ b/images/dash/README.md
@@ -1,0 +1,87 @@
+Official Blocknet dash Images
+=================================
+
+These dash docker images can be found on the docker hub: https://hub.docker.com/r/blocknetdx/dash/
+
+dash
+========
+
+These dash images are optimized for use with the Blocknet DX.
+
+**Note**
+
+These images are _not a replacement or endorsement_ of the dash project (https://github.com/dashpay/dash).
+
+
+Simple
+======
+
+Run a simple dash node on port 9999:
+```
+docker run -d --name=dash -p 9999:9999 blocknetdx/dash:v0.18.0.1
+```
+
+
+Persist blockchain w/ volumes
+=============================
+
+Run a dash node that persists the blockchain on a host directory. Recommended to avoid time consuming resyncs when updating to later container versions.
+```
+docker run -d --name=dash -p 9999:9999 -v=/crypto/dash/config:/opt/blockchain/config -v=/crypto/dash/data:/opt/blockchain/data blocknetdx/dash:v0.18.0.1
+```
+
+
+Automatically restart the container
+===================================
+
+See https://docs.docker.com/engine/admin/start-containers-automatically/
+
+`--restart=no|on-failure:retrycount|unless-stopped|always`
+
+```
+docker run -d --restart=no --name=dash -p 9999:9999 blocknetdx/dash:v0.18.0.1 dashd -daemon=0 -rpcuser=DASH -rpcpassword=DASH123
+docker run -d --restart=on-failure:10 --name=dash -p 9999:9999 blocknetdx/dash:v0.18.0.1 dashd -daemon=0 -rpcuser=DASH -rpcpassword=DASH123
+docker run -d --restart=unless-stopped --name=dash -p 9999:9999 blocknetdx/dash:v0.18.0.1 dashd -daemon=0 -rpcuser=DASH -rpcpassword=DASH123
+docker run -d --restart=always --name=dash -p 9999:9999 blocknetdx/dash:v0.18.0.1 dashd -daemon=0 -rpcuser=DASH -rpcpassword=DASH123
+```
+
+
+Container shell access
+======================
+
+To login to the dash container and run RPC commands use the following command:
+```
+docker exec -it dash /bin/bash
+```
+
+
+Default dash.conf
+=====================
+
+The default configuration is below. A custom configuration file can be passed to the dash  node container through the `/opt/blockchain/config` volume. Some of these parameters can also be adjusted on the command line.
+```
+datadir=/opt/blockchain/data
+
+dbcache=256
+maxmempool=512
+
+port=9999
+rpcport=9998
+
+listen=1
+txindex=1
+server=1
+maxconnections=16
+logtimestamps=1
+logips=1
+
+rpcallowip=127.0.0.1
+rpcwaittimeout=30
+rpcclienttimeout=30
+```
+
+
+License
+=======
+
+This code is licensed under the Apache 2.0 License. Please refer to the [LICENSE](https://github.com/BlocknetDX/dockerimages/blob/master/LICENSE).


### PR DESCRIPTION
Dash had a mandatory wallet upgrade on 17 August 2022.

All users need to upgrade to 18.0.1 and (especially if their chain is stuck at block 1738697) follow these steps:

dash-cli invalidateblock 0000000000000001342be9c0b75ad40c276beaad91616423c4d9cb101b3db438
dash-cli mnsync reset
dash-cli clearbanned
dash-cli reconsiderblock 0000000000000001342be9c0b75ad40c276beaad91616423c4d9cb101b3db438
See https://dashorg.freshdesk.com/en/support/solutions/articles/26000050175