### PR TITLE
Update Dockerfile.j2

### DIFF
--- a/autobuild/Dockerfile.j2
+++ b/autobuild/Dockerfile.j2
@@ -45,7 +45,10 @@ RUN mkdir -p /opt/{{ walletLinuxDir }} \
   && ./autogen.sh \
   && ./configure CC="gcc-8" CXX="g++-8" CXXFLAGS="-Wno-error=return-type" --with-gui=no --enable-hardening --prefix=`pwd`/depends/x86_64-pc-linux-gnu \
   && make -j$ecores \
-  && make install DESTDIR=$DISTDIR \
+  {% if walletName == 'pivx' %}
+&& ./params/install-params.sh \
+  {% endif %}
+&& make install DESTDIR=$DISTDIR \
   && cp $DISTDIR/opt/{{ walletLinuxDir }}/{{ walletLinuxDir }}/depends/x86_64-pc-linux-gnu/bin/* /usr/bin/ \
   && rm -rf /opt/{{ walletLinuxDir }}/
 


### PR DESCRIPTION
add this mandatory script start for pivx wallet.

"In order to run, all versions after 5.0.0, PIVX Core requires two files, sapling-output.params and sapling-spend.params (with total size ~50 MB), to be saved in a specific location. ...
macOS/Linux tar.gz tarballs include a bash script (install-params.sh) to copy the parameters in the appropriate location."