### PR TITLE
fix generate_build_files.py

### DIFF
--- a/autobuild/generate_build_files.py
+++ b/autobuild/generate_build_files.py
@@ -89,10 +89,11 @@ for blockchain in manifest_config:
         else:
             if wallet_version in walletVerList:
                 walletVersion = wallet_version
-            else:
-                sys.exit(f'Wallet version not found {wallet_version}')
-        walletGitTag = walletVersion
-        walletNameVerId = walletVersion
+                walletGitTag = walletVersion
+                walletNameVerId = walletVersion
+                
+if not walletVersion:
+    sys.exit(f'Wallet version not found {wallet_version}')
 
 
 

--- a/autobuild/generate_build_files.py
+++ b/autobuild/generate_build_files.py
@@ -62,7 +62,8 @@ if not manifest_config:
         exit
 else:
     manifest_config = json.loads(manifest_config)
- 
+
+found = False
 for blockchain in manifest_config:
     if re.sub('\s+', '-', blockchain['blockchain'].lower()) == blockchain_name.lower():
         if 'daemon_stem' in blockchain:
@@ -91,6 +92,10 @@ for blockchain in manifest_config:
                 walletVersion = wallet_version
                 walletGitTag = walletVersion
                 walletNameVerId = walletVersion
+                found = True
+
+if not found:
+    sys.exit(f'Wallet version not found {wallet_version}')
                 
 if not walletVersion:
     sys.exit(f'Wallet version not found {wallet_version}')


### PR DESCRIPTION
fix to "generate_build_files.py",
to keep searching for other wallets versions, in case of multiple concurrent wallet versions supported, 
ie BTC,
pre patch, script fail after picking the first version it could grab on list:
    "blockchain": "Bitcoin",
    "ticker": "BTC",
    "ver_id": "bitcoin--v0.15.1",
    
error: 
['v0.15.1', 'v0.15.2']
Wallet version not found v0.22.0

after this fix:
it will keep checking other wallet versions until it find the good one.
tested on BTC.