### PR TITLE
Update Dockerfile.j2

### DIFF
--- a/autobuild/Dockerfile.j2
+++ b/autobuild/Dockerfile.j2
@@ -39,6 +39,9 @@ RUN mkdir -p /opt/{{ walletLinuxDir }} \
   && git clone --depth 1 --branch {{ walletGitTag }} {{ walletGitURL }} {{ walletLinuxDir }} \
   && cd /opt/{{ walletLinuxDir }}/{{ walletLinuxDir }}/ \
   && cd depends \
+  {% if walletName == 'dash' %}
+&& sed -i "s/\$(package)_download_path=https:\/\/gmplib.org\/download\/gmp/\$(package)_download_path=https:\/\/ftp.gnu.org\/gnu\/gmp/" packages/gmp.mk \
+  {% endif %}  
   && make -j$ecores NO_QT=1 \
   && cd .. \
   && chmod +x ./autogen.sh \


### PR DESCRIPTION
add some fix for dash wallet depends failing to pick gmplib package after this repo banned GH actions ip ranges,

command replace on the fly dash depends gmp url to another working url: 

https://gmplib.org/download/gmp
to 
https://ftp.gnu.org/gnu/gmp